### PR TITLE
label map storage

### DIFF
--- a/yapic/main.py
+++ b/yapic/main.py
@@ -78,6 +78,7 @@ from docopt import docopt
 
 import os
 import sys
+import h5py
 from yapic.session import Session
 from yapic.deepimagej_exporter import DeepimagejExporter
 
@@ -158,6 +159,10 @@ def main(args):
                 steps_per_epoch=steps_per_epoch,
                 log_filename=log_filename,
                 model_filename=model_export_filename)
+        
+        f = h5py.File(model_export_filename, 'r+')
+        lbl_map_list = [[key, val] for key, val in s.lbl_map.items()]
+        f.create_dataset('lbl_map', data=lbl_map_list)
 
     if args['predict']:
         output_path = args['<output_path>']

--- a/yapic/session.py
+++ b/yapic/session.py
@@ -31,6 +31,9 @@ class Session(object):
     def __init__(self):
 
         self.dataset = None
+        
+        self.lbl_map = None
+        
         self.model = None
         self.data = None
         self.data_val = None
@@ -53,8 +56,11 @@ class Session(object):
             Path to folder with label tiff images or path to ilastik project
             file (.ilp file).
         '''
-
-        self.dataset = Dataset(io_connector(image_path, label_path))
+        
+        _connector = io_connector(image_path, label_path)
+        self.lbl_map = _connector.labelvalue_mapping[0]
+        
+        self.dataset = Dataset(_connector)
 
         msg = '\n\nImport taining dataset:\n{}\n'.format(
             self.dataset.pixel_connector.__repr__())


### PR DESCRIPTION
This modification now stores the label mapping between the original labels and the training labels in the h5 model file. This addition does not affect the YAPiC prediction and the information can be used later in software like Napari to be label value consistent with the training data.