### PR TITLE
added leaves example end2end training test 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
   - pip install tensorflow==$TENSORFLOW_VERSION
   - pip install .
   - pip install -U pytest
+  - pip install pytest-console-scripts
 script:
   - pytest -s -v -m "not slow"
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - '3.8'
 env:
-  - TENSORFLOW_VERSION=2.8.0
+  - TENSORFLOW_VERSION=2.4.1
 
 install:
   - pip install --upgrade pip setuptools

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,8 +95,13 @@ Development of YAPiC started in 2015, when Ronneberger et al. presented a [U-sha
 
 * Install YAPiC
 
+
+We recommend to install legacy YAPiC version which supports Ilastik label files. The current YAPiC version does not support Ilastik any more. Instead a label and prediction workflow with *napari* is supported. However the *napari* workflow for labelliing, YAPiC model training and prediction has not been documented so far. 
+The tutorials you finde here in the documentations work only with `yapic_io<=0.2.3` and `yapic<=1.2.4`. 
 ```
-pip install yapic
+pip install tensorflow==2.4.1 # you may use other tensorflow versions regarding to your hardware
+pip install yapic_io==0.2.3 # last version supporting Ilastik label files
+pip install yapic==1.2.4 # newer yapic versions require yapic_io>0.2.3
 ```
 
 

--- a/yapic/tests/test_cli.py
+++ b/yapic/tests/test_cli.py
@@ -14,7 +14,7 @@ def leaves_example_data_path(tmp_path):
         zip_ref.extractall(tmp_path)
     return tmp_path
 
-
+@pytest.mark.skip('ilp label files are not supported in current version')
 def test_leafexample_train(leaves_example_data_path, script_runner: ScriptRunner):
     # "'{}/*.tif'".format(str(leaves_example_data_path))
     image_path = str(leaves_example_data_path)

--- a/yapic/tests/test_cli.py
+++ b/yapic/tests/test_cli.py
@@ -7,20 +7,22 @@ from pytest_console_scripts import ScriptRunner
 
 @pytest.fixture
 def leaves_example_data_path(tmp_path):
-    zip_data_path = Path(__file__).parent.parent.parent / 'docs/example_data/leaves_example_data.zip'
+    zip_data_path = Path(__file__).parent.parent.parent / \
+        'docs/example_data/leaves_example_data.zip'
     assert zip_data_path.exists()
     with zipfile.ZipFile(zip_data_path, 'r') as zip_ref:
         zip_ref.extractall(tmp_path)
-    return tmp_path    
+    return tmp_path
+
 
 def test_leafexample_train(leaves_example_data_path, script_runner: ScriptRunner):
-    image_path = str(leaves_example_data_path) #"'{}/*.tif'".format(str(leaves_example_data_path))
-    label_path = "{}/leaf_labels_ilastik133.ilp".format(str(leaves_example_data_path))
+    # "'{}/*.tif'".format(str(leaves_example_data_path))
+    image_path = str(leaves_example_data_path)
+    label_path = "{}/leaf_labels_ilastik133.ilp".format(
+        str(leaves_example_data_path))
     assert Path(label_path).exists()
-    
-    ret = script_runner.run('yapic', 'train', 'unet_2d', image_path, label_path, '-e', '1', '--steps', '2')
-    
+
+    ret = script_runner.run('yapic', 'train', 'unet_2d',
+                            image_path, label_path, '-e', '1', '--steps', '2')
+
     assert ret.success
-
-   
-

--- a/yapic/tests/test_cli.py
+++ b/yapic/tests/test_cli.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import zipfile
+import os
+import pytest
+from pytest_console_scripts import ScriptRunner
+
+
+@pytest.fixture
+def leaves_example_data_path(tmp_path):
+    zip_data_path = Path(__file__).parent.parent.parent / 'docs/example_data/leaves_example_data.zip'
+    assert zip_data_path.exists()
+    with zipfile.ZipFile(zip_data_path, 'r') as zip_ref:
+        zip_ref.extractall(tmp_path)
+    return tmp_path    
+
+def test_leafexample_train(leaves_example_data_path, script_runner: ScriptRunner):
+    image_path = str(leaves_example_data_path) #"'{}/*.tif'".format(str(leaves_example_data_path))
+    label_path = "{}/leaf_labels_ilastik133.ilp".format(str(leaves_example_data_path))
+    assert Path(label_path).exists()
+    
+    ret = script_runner.run('yapic', 'train', 'unet_2d', image_path, label_path, '-e', '1', '--steps', '2')
+    
+    assert ret.success
+
+   
+

--- a/yapic/tests/test_session.py
+++ b/yapic/tests/test_session.py
@@ -177,16 +177,16 @@ class TestEnd2End(TestCase):
                 shape = 'triangles'
 
             filename = os.path.join(
-                                savepath,
-                                'pixels_{}_class_{}.tif'.format(image_nr,
-                                                                class_nr))
+                savepath,
+                'pixels_{}_class_{}.tif'.format(image_nr,
+                                                class_nr))
             print(filename)
             prediction_img = np.squeeze(imread(filename))
             filename = os.path.join(
-                                    savepath,
-                                    '../shapes/val/{}_{}.tiff'.format(
-                                        shape,
-                                        image_nr))
+                savepath,
+                '../shapes/val/{}_{}.tiff'.format(
+                    shape,
+                    image_nr))
             print(filename)
             val_img = np.squeeze(skimage.io.imread(filename))
             return prediction_img, val_img


### PR DESCRIPTION
Fixes #56 
The leaves example used in the tutorial is not working any more.
* The problem has to be solved in yapic_io
* I added a  test of yapic cli training with the leaves example data in the tutorial.


I figured this is mainly a documentation problem. I did a quick fix in the documentation to guide the users to installing legacy yapic version.